### PR TITLE
[TEAM-498] Use self-hosted GitHub runners for actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Beep-boop! This is automatic pull-request to update github actions runners and explicitly use self-hosted.
Ask @Romanavr in Slack if you have questions